### PR TITLE
docs: updating the examples for advance usecase

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,50 @@ module "dcos" {
   num_private_agentss = "2"
   num_public_agentss = "1"
 
+  dcos_cluster_docker_credentials_enabled =  "true"
+  dcos_cluster_docker_credentials_write_to_etc = "true"
+  dcos_cluster_docker_credentials_dcos_owned = "false"
+  dcos_cluster_docker_registry_url = "https://index.docker.io"
+  dcos_use_proxy = "yes"
+  dcos_http_proxy = "example.com"
+  dcos_https_proxy = "example.com"
+  dcos_no_proxy = <<EOF
+  # YAML
+   - "internal.net"
+   - "169.254.169.254"
+  EOF
+  dcos_overlay_network = <<EOF
+  # YAML
+      vtep_subnet: 44.128.0.0/20
+      vtep_mac_oui: 70:B3:D5:00:00:00
+      overlays:
+        - name: dcos
+          subnet: 12.0.0.0/8
+          prefix: 26
+  EOF
+  dcos_rexray_config = <<EOF
+  # YAML
+    rexray:
+      loglevel: warn
+      modules:
+        default-admin:
+          host: tcp://127.0.0.1:61003
+      storageDrivers:
+      - ec2
+      volume:
+        unmount:
+          ignoreusedcount: true
+  EOF
+  dcos_cluster_docker_credentials = <<EOF
+  # YAML
+    auths:
+      'https://index.docker.io/v1/':
+        auth: Ze9ja2VyY3licmljSmVFOEJrcTY2eTV1WHhnSkVuVndjVEE=
+  EOF
+
+  # dcos_variant              = "ee"
+  # dcos_license_key_contents = "${file("./license.txt")}"
   dcos_variant = "open"
-  # dcos_license_key_contents = ""
 }
 ```
 
@@ -35,7 +77,6 @@ module "dcos" {
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | admin_ips | List of CIDR admin IPs | list | - | yes |
-| availability_zones | Availability zones to be used | list | `<list>` | no |
 | bootstrap_image | [BOOTSTRAP] Image to be used | map | `<map>` | no |
 | bootstrap_os | [BOOTSTRAP] Operating system to use. Instead of using your own AMI you could use a provided OS. | string | `` | no |
 | bootstrap_private_ip | used for the private ip for the bootstrap url | string | `` | no |

--- a/main.tf
+++ b/main.tf
@@ -25,8 +25,50 @@
  *   num_private_agentss = "2"
  *   num_public_agentss = "1"
  *
+ *   dcos_cluster_docker_credentials_enabled =  "true"
+ *   dcos_cluster_docker_credentials_write_to_etc = "true"
+ *   dcos_cluster_docker_credentials_dcos_owned = "false"
+ *   dcos_cluster_docker_registry_url = "https://index.docker.io"
+ *   dcos_use_proxy = "yes"
+ *   dcos_http_proxy = "example.com"
+ *   dcos_https_proxy = "example.com"
+ *   dcos_no_proxy = <<EOF
+ *   # YAML
+ *    - "internal.net"
+ *    - "169.254.169.254"
+ *   EOF
+ *   dcos_overlay_network = <<EOF
+ *   # YAML
+ *       vtep_subnet: 44.128.0.0/20
+ *       vtep_mac_oui: 70:B3:D5:00:00:00
+ *       overlays:
+ *         - name: dcos
+ *           subnet: 12.0.0.0/8
+ *           prefix: 26
+ *   EOF
+ *   dcos_rexray_config = <<EOF
+ *   # YAML
+ *     rexray:
+ *       loglevel: warn
+ *       modules:
+ *         default-admin:
+ *           host: tcp://127.0.0.1:61003
+ *       storageDrivers:
+ *       - ec2
+ *       volume:
+ *         unmount:
+ *           ignoreusedcount: true
+ *   EOF
+ *   dcos_cluster_docker_credentials = <<EOF
+ *   # YAML
+ *     auths:
+ *       'https://index.docker.io/v1/':
+ *         auth: Ze9ja2VyY3licmljSmVFOEJrcTY2eTV1WHhnSkVuVndjVEE=
+ *   EOF
+ *
+ *   # dcos_variant              = "ee"
+ *   # dcos_license_key_contents = "${file("./license.txt")}"
  *   dcos_variant = "open"
- *   # dcos_license_key_contents = ""
  * }
  *```
  */

--- a/variables.tf
+++ b/variables.tf
@@ -43,12 +43,6 @@ variable "admin_ips" {
   type        = "list"
 }
 
-variable "availability_zones" {
-  type        = "list"
-  description = "Availability zones to be used"
-  default     = []
-}
-
 variable "cluster_name_random_string" {
   description = "Add a random string to the cluster name"
   default     = false


### PR DESCRIPTION
Users need to know how to configure their universal installer main.tf and this change shows different examples can be used. Especially the most complex examples with yaml settings.