### PR TITLE
updating the version properly pin patch version

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Get started with using this module by reading the documentation here: [README.md
 ```hcl
 module "dcos" {
   source  = "dcos-terraform/dcos/azurerm"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   cluster_name = "mydcoscluster"
   infra_public_ssh_key_path = "~/.ssh/key.pub"

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -99,7 +99,7 @@ $ cat main.tf
 ...
 module "dcos" {
   source  = "dcos-terraform/dcos/azurerm"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   # additional example variables in the module
   dcos_version = "1.11.5"

--- a/docs/published/README.md
+++ b/docs/published/README.md
@@ -135,7 +135,7 @@ data "http" "whatismyip" {
 
 module "dcos" {
   source  = "dcos-terraform/dcos/azurerm"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   dcos_instance_os    = "coreos_1855.5.0"
   cluster_name        = "my-dcos"
@@ -240,7 +240,7 @@ data "http" "whatismyip" {
 
 module "dcos" {
   source  = "dcos-terraform/dcos/azurerm"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   dcos_instance_os    = "coreos_1855.5.0"
   cluster_name        = "my-dcos"
@@ -329,7 +329,7 @@ data "http" "whatismyip" {
 
 module "dcos" {
   source  = "dcos-terraform/dcos/azurerm"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   dcos_instance_os    = "coreos_1855.5.0"
   cluster_name        = "my-dcos"

--- a/docs/published/main.tf
+++ b/docs/published/main.tf
@@ -9,7 +9,7 @@ data "http" "whatismyip" {
 
 module "dcos" {
   source  = "dcos-terraform/dcos/azurerm"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   dcos_instance_os    = "coreos_1855.5.0"
   cluster_name        = "my-open-dcos-cluster"

--- a/main.tf
+++ b/main.tf
@@ -15,7 +15,7 @@
  *```hcl
  * module "dcos" {
  *   source  = "dcos-terraform/dcos/azurerm"
- *   version = "~> 0.1"
+ *   version = "~> 0.1.0"
  *
  *   cluster_name = "mydcoscluster"
  *   infra_public_ssh_key_path = "~/.ssh/key.pub"


### PR DESCRIPTION
This updates the version behaivor to have ~> 0.1.0: any non-beta version >= 0.1.0 and < 0.2.0

https://www.terraform.io/docs/modules/usage.html#gt-1-2