### PR TITLE
ip-detect.sh to fail on error per DCOS-45817

### DIFF
--- a/scripts/fault-domain-detect.sh
+++ b/scripts/fault-domain-detect.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -o nounset -o errexit
 
 AWS_URL="http://169.254.169.254/latest/dynamic/instance-identity/document"
 

--- a/scripts/ip-detect.sh
+++ b/scripts/ip-detect.sh
@@ -2,4 +2,6 @@
 # Example ip-detect script using an external authority
 # Uses the AWS Metadata Service to get the node's internal
 # ipv4 address
+set -o nounset -o errexit
+
 curl -H Metadata:true -fsSL "http://169.254.169.254/metadata/instance/network/interface/0/ipv4/ipAddress/0/privateIpAddress?api-version=2017-04-02&format=text"


### PR DESCRIPTION
This feature was requested because of a customer issue faced because the script failed but continued COPS-4180. 

Per COPS-4180, "The detect_ip script has failed when secrets service was started by systemd. This failure resulted in missing value for -node-id flag which later picked bootstrap flag as a node-id value. The -bootstrap was then missing, which is the flag that instructs the secret service to auto unseal the default vault backend."