### PR TITLE
var: updating dcos_exhibitor_storage_backend desc

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ module "dcos" {
 | dcos_exhibitor_azure_account_name | the azure account name for exhibitor storage (optional but required with dcos_exhibitor_address) | string | `` | no |
 | dcos_exhibitor_azure_prefix | the azure account name for exhibitor storage (optional but required with dcos_exhibitor_address) | string | `` | no |
 | dcos_exhibitor_explicit_keys | set whether you are using AWS API keys to grant Exhibitor access to S3. (optional) | string | `` | no |
-| dcos_exhibitor_storage_backend | options are aws_s3, azure, or zookeeper (recommended) | string | `static` | no |
+| dcos_exhibitor_storage_backend | options are static, aws_s3, azure, or zookeeper (recommended) | string | `static` | no |
 | dcos_exhibitor_zk_hosts | a comma-separated list of one or more ZooKeeper node IP and port addresses to use for configuring the internal Exhibitor instances. (not recommended but required with exhibitor_storage_backend set to ZooKeeper. Use aws_s3 or azure instead. Assumes external ZooKeeper is already online.) | string | `` | no |
 | dcos_exhibitor_zk_path | the filepath that Exhibitor uses to store data (not recommended but required with exhibitor_storage_backend set to `zookeeper`. Use `aws_s3` or `azure` instead. Assumes external ZooKeeper is already online.) | string | `` | no |
 | dcos_fault_domain_detect_contents | [Enterprise DC/OS] fault domain script contents. Optional but required if no fault-domain-detect script present. | string | `` | no |

--- a/dcos_core_variables.tf
+++ b/dcos_core_variables.tf
@@ -85,7 +85,7 @@ variable "dcos_aws_template_storage_secret_access_key" {
 
 variable "dcos_exhibitor_storage_backend" {
   default     = "static"
-  description = "options are aws_s3, azure, or zookeeper (recommended)"
+  description = "options are static, aws_s3, azure, or zookeeper (recommended)"
 }
 
 variable "dcos_exhibitor_zk_hosts" {


### PR DESCRIPTION
https://jira.mesosphere.com/browse/DCOS-47936

The description was missing the static option for the dcos_exhibitor_storage_backend variable. This commit fixes this across the repositories.