### PR TITLE
module: added the subnet_range variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ module "dcos" {
 | public_agents_vm_size | [PUBLIC AGENTS] Azure virtual machine size | string | `Standard_D4s_v3` | no |
 | ssh_public_key | SSH public key in authorized keys format (e.g. 'ssh-rsa ..') to be used with the instances. Make sure you added this key to your ssh-agent. | string | `` | no |
 | ssh_public_key_file | Path to SSH public key. This is mandatory but can be set to an empty string if you want to use ssh_public_key with the key as string. | string | - | yes |
+| subnet_range | Private IP space to be used in CIDR format | string | `172.12.0.0/16` | no |
 | tags | Add custom tags to all resources | map | `<map>` | no |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -121,6 +121,7 @@ module "dcos-infrastructure" {
   num_private_agents = "${var.num_private_agents}"
   num_public_agents  = "${var.num_public_agents}"
   admin_ips          = "${var.admin_ips}"
+  subnet_range       = "${var.subnet_range}"
 
   location     = "${var.location}"
   tags         = "${var.tags}"

--- a/variables.tf
+++ b/variables.tf
@@ -158,3 +158,8 @@ variable "public_agents_additional_ports" {
   description = "List of additional ports allowed for public access on public agents (80 and 443 open by default)"
   default     = []
 }
+
+variable "subnet_range" {
+  description = "Private IP space to be used in CIDR format"
+  default     = "172.12.0.0/16"
+}


### PR DESCRIPTION
This is to add support to allow users to input a desired subnet_range to their existing cloud infrastructure. Currently we are defaulting to the non supported `172.12.0.0/16` CIDR range. A subsequent 0.2.0 release of this will have the correct range of `172.16.0.0/16` version.