### PR TITLE
scripts: reverting fault domain script

### DIFF
--- a/scripts/fault-domain-detect.sh
+++ b/scripts/fault-domain-detect.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -o nounset -o errexit
 
 AWS_URL="http://169.254.169.254/latest/dynamic/instance-identity/document"
 


### PR DESCRIPTION
This is to revert the change to include the checks for the fault domain detect script. This will no longer be an issue once with CI/CD integration test begins for dcos-terraform exist.