### PR TITLE
Add config options for setting Admin Router gRPC port

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -131,6 +131,8 @@ module "dcos-infrastructure" {
   # If defining external exhibitor storage
   azurerm_storage_account_name = "${var.dcos_exhibitor_azure_account_name}"
 
+  adminrouter_grpc_proxy_port = "${var.adminrouter_grpc_proxy_port}"
+
   providers = {
     azurerm = "azurerm"
   }
@@ -282,4 +284,5 @@ module "dcos-core" {
   dcos_zk_master_credentials                   = "${var.dcos_zk_master_credentials}"
   dcos_zk_super_credentials                    = "${var.dcos_zk_super_credentials}"
   dcos_enable_mesos_input_plugin               = "${var.dcos_enable_mesos_input_plugin}"
+  adminrouter_grpc_proxy_port                  = "${var.adminrouter_grpc_proxy_port}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -200,3 +200,8 @@ variable "ansible_additional_config" {
   default     = ""
   description = "Add additional config options to ansible. This is getting merged with generated defaults. Do not specify `dcos:`"
 }
+
+variable "adminrouter_grpc_proxy_port" {
+  description = ""
+  default     = 12379
+}


### PR DESCRIPTION
This PR adds support for Add config options for setting Admin Router gRPC port. See the Jira issue below for more details:

https://jira.d2iq.com/browse/D2IQ-62476